### PR TITLE
Fix a wrongly generated doc for to many relations

### DIFF
--- a/src/Descriptors/Schema/Schema.php
+++ b/src/Descriptors/Schema/Schema.php
@@ -179,20 +179,7 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
               ->resource(Arr::first($route->inversSchemas())::model());
         }
 
-        $inverseRelation = $route->relation() !== null ? $route->relation()->inverse() : null;
-        $relation = $route->relation();
-
-        $dataSchema = $this
-          ->relationshipData(
-            $relation,
-            $resource,
-            $inverseRelation
-          );
-
-        if ($relation instanceof Eloquent\Fields\Relations\ToMany) {
-            $dataSchema = OASchema::array('data')
-              ->items($dataSchema);
-        }
+        $dataSchema = $this->getDataSchema($route, $resource);
 
         return $dataSchema->title('Resource/'.ucfirst($route->name(true)).'/Relationship/'.ucfirst($route->relationName()).'/Update');
     }
@@ -211,21 +198,7 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
               ->resource(Arr::first($route->inversSchemas())::model());
         }
 
-        $inverseRelation = $route->relation() !== null ? $route->relation()->inverse() : null;
-
-        $relation = $route->relation();
-
-        $dataSchema = $this
-          ->relationshipData(
-            $relation,
-            $resource,
-            $inverseRelation
-          );
-
-        if ($relation instanceof Eloquent\Fields\Relations\ToMany) {
-            $dataSchema = OASchema::array('data')
-              ->items($dataSchema);
-        }
+        $dataSchema = $this->getDataSchema($route, $resource);
 
         return $dataSchema->title('Resource/'.ucfirst($route->name(true)).'/Relationship/'.ucfirst($route->relationName()).'/Attach');
     }
@@ -243,10 +216,9 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
             $resource = $this->generator->resources()
               ->resource(Arr::first($route->inversSchemas())::model());
         }
-      $inverseRelation = $route->relation() !== null ? $route->relation()->inverse() : null;
-        return $this->relationshipData($route->relation(), $resource,
-          $inverseRelation)
-          ->title('Resource/'.ucfirst($route->name(true)).'/Relationship/'.ucfirst($route->relationName()).'/Detach');
+        $dataSchema = $this->getDataSchema($route, $resource);
+
+        return $dataSchema->title('Resource/'.ucfirst($route->name(true)).'/Relationship/'.ucfirst($route->relationName()).'/Detach');
     }
 
     /**
@@ -607,6 +579,32 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
                 return $descriptor;
             }
         }
+    }
+
+    /**
+     * @param Route $route
+     * @param JsonApiResource $resource
+     * @return OASchema
+     * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
+     */
+    protected function getDataSchema(Route $route, JsonApiResource $resource): OASchema
+    {
+        $inverseRelation = $route->relation() !== null ? $route->relation()->inverse() : null;
+
+        $relation = $route->relation();
+
+        $dataSchema = $this
+            ->relationshipData(
+                $relation,
+                $resource,
+                $inverseRelation
+            );
+
+        if ($relation instanceof Eloquent\Fields\Relations\ToMany) {
+            $dataSchema = OASchema::array('data')
+                ->items($dataSchema);
+        }
+        return $dataSchema;
     }
 
 }

--- a/tests/Feature/OpenApiSchemaTest.php
+++ b/tests/Feature/OpenApiSchemaTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LaravelJsonApi\OpenApiSpec\Facades\GeneratorFacade;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Database\Seeders\DatabaseSeeder;
+use LaravelJsonApi\OpenApiSpec\Tests\TestCase;
+
+class OpenApiSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $spec;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(DatabaseSeeder::class);
+
+        $output = GeneratorFacade::generate('v1', 'json');
+        $this->spec = json_decode($output, true);
+    }
+
+    public function test_has_many_should_have_array_as_type(): void
+    {
+        $this->assertEquals('array', $this->spec['components']['schemas']['resources.posts.relationship.tags.update']['type']);
+        $this->assertEquals('array', $this->spec['components']['schemas']['resources.posts.relationship.tags.attach']['type']);
+        $this->assertEquals('array', $this->spec['components']['schemas']['resources.posts.relationship.tags.detach']['type']);
+    }
+}


### PR DESCRIPTION
When a relation what specified as a to many relationship it would generate a wrong documentation for the detach endpoint.
Before my fix it expected an object instead of an array.

Before this fix:
```
{
    "data": {
        "type": "tags",
        "id": "<string>"
    }
}
```

After this fix:
```
{
    "data": [
        {
            "type": "tags",
            "id": "<string>"
        },
        {
            "type": "tags",
            "id": "<string>"
        }
    ]
}
```