### PR TITLE
Fix error on routes without name on PHP8.1

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -281,8 +281,13 @@ class Route
       IlluminateRoute $route,
       Server $server
     ): bool {
+        $routeName = $route->getName();
+        if ($routeName === null) {
+            return false;
+        }
+
         return Str::contains(
-          $route->getName(),
+          $routeName,
           $server->name(),
         );
     }


### PR DESCRIPTION
Str::contains calls mb_strpos internally with the routeName as the haystack, which causes an errorException with message `mb_strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated` when routes without names are present. This PR fixes that issue.
