### PR TITLE
Fix unpacking on null TypeError when attributes are not set

### DIFF
--- a/src/Descriptors/Schema/Schema.php
+++ b/src/Descriptors/Schema/Schema.php
@@ -73,7 +73,7 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
           OASchema::string('id')
             ->example($resource->id()),
           OASchema::object('attributes')
-            ->properties(...$fields->get('attributes')),
+            ->properties(...$fields->get('attributes') ?: []),
         ];
 
         if ($fields->has('relationships')) {
@@ -109,7 +109,7 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
               ->title('type')
               ->default($route->name()),
             OASchema::object('attributes')
-              ->properties(...$fields->get('attributes')),
+              ->properties(...$fields->get('attributes') ?: []),
             OASchema::object('relationships')
               ->properties(...$fields->get('relationships') ?: [])
           );
@@ -138,7 +138,7 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
             OASchema::string('id')
               ->example($resource->id()),
             OASchema::object('attributes')
-              ->properties(...$fields->get('attributes')),
+              ->properties(...$fields->get('attributes') ?: []),
             OASchema::object('relationships')
               ->properties(...$fields->get('relationships') ?: [])
           )


### PR DESCRIPTION
When the attributes field is empty it returns null, which is not an array or traversable so cannot be unpacked. This results in a TypeError, which is fixed in this PR.