### PR TITLE
feat: allow customizing the Storage disk to use

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -13,5 +13,15 @@ return [
                 'version' => '1.0.0',
             ],
         ],
-    ]
+    ],
+
+    /**
+     * The storage disk to be used to place the generated `*_openapi.json` or `*_openapi.yaml` file.
+     *
+     * For example, if you use 'public' you can access the generated file as public web asset (after run `php artisan storage:link`).
+     *
+     * Supported: 'local', 'public' and (probably) any disk available in your filesystems (https://laravel.com/docs/9.x/filesystem#configuration).
+     * Set it to `null` to use your default disk.
+     */
+    'filesystem_disk' => env('OPEN_API_SPEC_GENERATOR_FILESYSTEM_DISK', null),
 ];

--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -4,6 +4,7 @@ namespace LaravelJsonApi\OpenApiSpec\Commands;
 
 use GoldSpecDigital\ObjectOrientedOAS\Exceptions\ValidationException;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
 use LaravelJsonApi\OpenApiSpec\Facades\GeneratorFacade;
 
 class GenerateCommand extends Command
@@ -52,13 +53,18 @@ class GenerateCommand extends Command
             return 1;
         }
 
-        $this->line('Complete! /storage/app/'.$serverKey.'_openapi.' . $format);
+        /** @var \Illuminate\Filesystem\FilesystemAdapter $storageDisk */
+        $storageDisk = Storage::disk(config('openapi.filesystem_disk'));
+
+        $fileName = $serverKey . '_openapi.' . $format;
+        $filePath = str_replace(base_path() . '/', '', $storageDisk->path($fileName));
+
+        $this->line('Complete! ' . $filePath);
         $this->newLine();
         $this->line('Run the following to see your API docs');
-        $this->info('speccy serve storage/app/'.$serverKey.'_openapi.' . $format);
+        $this->info('speccy serve ' . $filePath);
         $this->newLine();
 
         return 0;
     }
-
 }

--- a/tests/Feature/GenerateTest.php
+++ b/tests/Feature/GenerateTest.php
@@ -4,6 +4,7 @@ namespace LaravelJsonApi\OpenApiSpec\Tests\Feature;
 
 use GoldSpecDigital\ObjectOrientedOAS\Exceptions\ValidationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
 use LaravelJsonApi\OpenApiSpec\Facades\GeneratorFacade;
 use LaravelJsonApi\OpenApiSpec\Tests\Support\Database\Seeders\DatabaseSeeder;
 use LaravelJsonApi\OpenApiSpec\Tests\TestCase;
@@ -42,25 +43,26 @@ class GenerateTest extends TestCase
     {
         GeneratorFacade::generate('v1');
 
-        $openapiYaml = \Storage::get('v1_openapi.yaml');
+        $openapiYaml = Storage::disk(config('openapi.filesystem_disk'))->get('v1_openapi.yaml');
 
         $spec = Yaml::parse($openapiYaml);
 
         $this->assertEquals('My JSON:API', $spec['info']['title']);
     }
 
+
     public function test_url_is_properly_parsed()
     {
-      GeneratorFacade::generate('v1');
+        GeneratorFacade::generate('v1');
 
-      $openapiYaml = GeneratorFacade::generate('v1');
+        $openapiYaml = GeneratorFacade::generate('v1');
 
-      $spec = Yaml::parse($openapiYaml);
+        $spec = Yaml::parse($openapiYaml);
 
-      $this->assertArrayHasKey('/posts', $spec['paths'], 'Path to resource is not replaced correctly.');
-      
-      $this->assertArrayHasKey('/posts/{post}/relationships/author', $spec['paths'], 'Path to resource is not replaced correctly.');
+        $this->assertArrayHasKey('/posts', $spec['paths'], 'Path to resource is not replaced correctly.');
 
-      $this->assertEquals('http://localhost/api/v1', $spec['servers'][0]['variables']['serverUrl']['default']);
+        $this->assertArrayHasKey('/posts/{post}/relationships/author', $spec['paths'], 'Path to resource is not replaced correctly.');
+
+        $this->assertEquals('http://localhost/api/v1', $spec['servers'][0]['variables']['serverUrl']['default']);
     }
 }


### PR DESCRIPTION
Add `openapi.filesystem_disk` config key and use it as storage disk to put the generated file, instead of the default one.


**Why?**
Allow publishing the generated file as a public asset and making it accessible by tools like https://github.com/stoplightio/elements and https://github.com/JustSteveKing/laravel-stoplight-elements.


**New config key:**

```php
return [
    /**
     * The storage disk to be used to place the generated `*_openapi.json` or `*_openapi.yaml` file.
     *
     * For example, if you use 'public' you can access the generated file as public web asset (after run `php artisan storage:link`).
     *
     * Supported: 'local', 'public' and (probably) any disk available in your filesystems (https://laravel.com/docs/9.x/filesystem#configuration).
     * Set it to `null` to use your default disk.
     */
    'filesystem_disk' => env('OPEN_API_SPEC_GENERATOR_FILESYSTEM_DISK', null),
];
```

> Note: This PR does not changes the default behaviour.