### PR TITLE
feat: add compatibility with laravel-json-api v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,14 +40,14 @@
         "php": ">=7.4|^8.0",
         "goldspecdigital/oooas": "^2.8",
         "justinrainbow/json-schema": "^5.2",
-        "laravel-json-api/hashids": "^1.1",
+        "laravel-json-api/hashids": "^1.1|^2.0",
         "symfony/yaml": "^5.3|^6.0"
     },
     "require-dev": {
         "ext-json": "*",
         "friendsofphp/php-cs-fixer": "^3.14",
-        "laravel-json-api/laravel": "^2.0",
-        "orchestra/testbench": "^6.25|^7.21",
+        "laravel-json-api/laravel": "^2.0|^3.0",
+        "orchestra/testbench": "^6.25|^7.21|^8.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {


### PR DESCRIPTION
Add compatibility with Laravel 10.

## Description

Update valid packages ranges to add compatibility with Laravel v10 and Laravel JSON:API v3.

## Motivation and context

Allow to be installed in Laravel 10 and using Laravel JSON:API 3.

## How has this been tested?

There seems not being any public API changes in required packages, just Laravel 10 compatibility.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](https://github.com/swisnl/openapi-spec-generator/blob/master/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
