### PR TITLE
Add configuration options for Server Info section

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -6,10 +6,24 @@
 return [
     'servers' => [
         'v1' => [
+            /*
+             * Info section: title and version are required, everything else can be commented out if not needed.
+             * See https://swagger.io/specification/#info-object for more information.
+             */
             'info' => [
                 'title' => 'My JSON:API',
                 'description' => 'JSON:API built using Laravel',
                 'version' => '1.0.0',
+                'termsOfService' => 'https://example.com/terms-of-service',
+                'license' => [
+                    'name' => 'MIT',
+                    'url' => 'https://opensource.org/licenses/MIT',
+                ],
+                'contact' => [
+                    'name' => 'API Support',
+                    'url' => 'https://www.example.com/support',
+                    'email' => 'support@example.com',
+                ],
             ],
         ],
     ],

--- a/src/Descriptors/Server.php
+++ b/src/Descriptors/Server.php
@@ -3,23 +3,36 @@
 namespace LaravelJsonApi\OpenApiSpec\Descriptors;
 
 use GoldSpecDigital\ObjectOrientedOAS\Objects;
+use Illuminate\Support\Arr;
 use LaravelJsonApi\OpenApiSpec\Descriptors\Descriptor as BaseDescriptor;
 
 class Server extends BaseDescriptor
 {
     /**
      * @return \GoldSpecDigital\ObjectOrientedOAS\Objects\Info
-     *
-     * @todo Add contact
-     * @todo Add TOS
-     * @todo Add License
      */
     public function info(): Objects\Info
     {
         return Objects\Info::create()
-          ->title(config("openapi.servers.{$this->generator->key()}.info.title"))
-          ->description(config("openapi.servers.{$this->generator->key()}.info.description"))
-          ->version(config("openapi.servers.{$this->generator->key()}.info.version"));
+            ->title(config("openapi.servers.{$this->generator->key()}.info.title"))
+            ->description(config("openapi.servers.{$this->generator->key()}.info.description"))
+            ->version(config("openapi.servers.{$this->generator->key()}.info.version"))
+            ->termsOfService(config("openapi.servers.{$this->generator->key()}.info.termsOfService"))
+            ->license(
+                Arr::has(config("openapi.servers.{$this->generator->key()}.info"), 'license')
+                    ? Objects\License::create()
+                    ->name(config("openapi.servers.{$this->generator->key()}.info.license.name"))
+                    ->url(config("openapi.servers.{$this->generator->key()}.info.license.url"))
+                    : null
+            )
+            ->contact(
+                Arr::has(config("openapi.servers.{$this->generator->key()}.info"), 'contact')
+                    ? Objects\Contact::create()
+                    ->name(config("openapi.servers.{$this->generator->key()}.info.contact.name"))
+                    ->email(config("openapi.servers.{$this->generator->key()}.info.contact.email"))
+                    ->url(config("openapi.servers.{$this->generator->key()}.info.contact.url"))
+                    : null
+            );
     }
 
     /**
@@ -32,11 +45,12 @@ class Server extends BaseDescriptor
     public function servers(): array
     {
         return [
-          Objects\Server::create()
-            ->url('{serverUrl}')
-            ->variables(Objects\ServerVariable::create('serverUrl')
-              ->default($this->generator->server()->url())
-            ),
+            Objects\Server::create()
+                ->url('{serverUrl}')
+                ->variables(
+                    Objects\ServerVariable::create('serverUrl')
+                        ->default($this->generator->server()->url())
+                ),
         ];
     }
 }

--- a/src/Descriptors/Server.php
+++ b/src/Descriptors/Server.php
@@ -21,16 +21,16 @@ class Server extends BaseDescriptor
             ->license(
                 Arr::has(config("openapi.servers.{$this->generator->key()}.info"), 'license')
                     ? Objects\License::create()
-                    ->name(config("openapi.servers.{$this->generator->key()}.info.license.name"))
-                    ->url(config("openapi.servers.{$this->generator->key()}.info.license.url"))
+                        ->name(config("openapi.servers.{$this->generator->key()}.info.license.name"))
+                        ->url(config("openapi.servers.{$this->generator->key()}.info.license.url"))
                     : null
             )
             ->contact(
                 Arr::has(config("openapi.servers.{$this->generator->key()}.info"), 'contact')
                     ? Objects\Contact::create()
-                    ->name(config("openapi.servers.{$this->generator->key()}.info.contact.name"))
-                    ->email(config("openapi.servers.{$this->generator->key()}.info.contact.email"))
-                    ->url(config("openapi.servers.{$this->generator->key()}.info.contact.url"))
+                        ->name(config("openapi.servers.{$this->generator->key()}.info.contact.name"))
+                        ->email(config("openapi.servers.{$this->generator->key()}.info.contact.email"))
+                        ->url(config("openapi.servers.{$this->generator->key()}.info.contact.url"))
                     : null
             );
     }

--- a/tests/Feature/OpenApiSchemaTest.php
+++ b/tests/Feature/OpenApiSchemaTest.php
@@ -41,4 +41,17 @@ class OpenApiSchemaTest extends TestCase
     {
         $this->assertEquals('', $this->spec['paths']['/videos']['get']['description']);
     }
+
+    public function testItUsesInfoConfig()
+    {
+        $this->assertEquals('My JSON:API', $this->spec['info']['title']);
+        $this->assertEquals('JSON:API built using Laravel', $this->spec['info']['description']);
+        $this->assertEquals('1.0.0', $this->spec['info']['version']);
+        $this->assertEquals('https://example.com/terms-of-service', $this->spec['info']['termsOfService']);
+        $this->assertEquals('MIT', $this->spec['info']['license']['name']);
+        $this->assertEquals('https://opensource.org/licenses/MIT', $this->spec['info']['license']['url']);
+        $this->assertEquals('API Support', $this->spec['info']['contact']['name']);
+        $this->assertEquals('https://www.example.com/support', $this->spec['info']['contact']['url']);
+        $this->assertEquals('support@example.com', $this->spec['info']['contact']['email']);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the ability to configure additional entries of the Info section:
- termsOfService
- license
- contact

## Motivation and context

It wasn't possible to do so before this PR and was in the TODO list. 
We need it for our current project

## How has this been tested?

Generation has been tested with and without the changes enabled, all works as intended. This is a very simple change.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](https://github.com/swisnl/openapi-spec-generator/blob/master/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
