### PR TITLE
Allow configuration of YAML output format through config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -23,4 +23,15 @@ return [
      * Set it to `null` to use your default disk.
      */
     'filesystem_disk' => env('OPEN_API_SPEC_GENERATOR_FILESYSTEM_DISK', null),
+
+    /*
+     * Dump option for the yaml output file, see https://symfony.com/doc/current/components/yaml.html#expanded-and-inlined-arrays
+     * If you want the yaml output to be fully expanded, set inline to a high value like 1000
+     */
+    'yaml' => [
+        'format' => [
+            'inline' => 2,
+            'indent' => 4
+        ]
+    ]
 ];

--- a/src/OpenApiGenerator.php
+++ b/src/OpenApiGenerator.php
@@ -19,10 +19,14 @@ class OpenApiGenerator
 
         $storageDisk = Storage::disk(config('openapi.filesystem_disk'));
 
-        $fileName = $serverKey.'_openapi.'.$format;
+        $fileName = $serverKey . '_openapi.' . $format;
 
         if ($format === 'yaml') {
-            $output = Yaml::dump($openapi->toArray());
+            $output = Yaml::dump(
+                $openapi->toArray(),
+                config('openapi.yaml.format.inline', 2),
+                config('openapi.yaml.format.indent', 4)
+            );
         } elseif ($format === 'json') {
             $output = json_encode($openapi->toArray(), JSON_PRETTY_PRINT);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds an option to control the inline and indent of the yaml output through config

## Motivation and context

Useful for readability of exported yaml file, especially during development of the api when you might not have a solution yet to display the docs in an actual frontend.
It is also coherent with the json output format using the JSON_PRETTY_PRINT flag, this PR allows you to pretty print the YAML file if you wish to do so.
It is backward compatible with default values not changing behavior for existing installs

## How has this been tested?

Tested the output while changing config values, all works as expected

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](https://github.com/swisnl/openapi-spec-generator/blob/master/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
