### PR TITLE
Support non-Eloquent resource

### DIFF
--- a/src/Descriptors/Schema/Schema.php
+++ b/src/Descriptors/Schema/Schema.php
@@ -6,8 +6,10 @@ use GoldSpecDigital\ObjectOrientedOAS\Objects\Parameter;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema as OASchema;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use LaravelJsonApi\Contracts\Schema\Attribute as AttributeContract;
 use LaravelJsonApi\Contracts\Schema\Field;
 use LaravelJsonApi\Contracts\Schema\PolymorphicRelation;
+use LaravelJsonApi\Contracts\Schema\Relation as RelationContract;
 use LaravelJsonApi\Contracts\Schema\Schema as JASchema;
 use LaravelJsonApi\Contracts\Schema\Sortable;
 use LaravelJsonApi\Core\Resources\JsonApiResource;
@@ -15,12 +17,10 @@ use LaravelJsonApi\Core\Support\Str;
 use LaravelJsonApi\Eloquent;
 use LaravelJsonApi\Eloquent\Fields\ArrayHash;
 use LaravelJsonApi\Eloquent\Fields\ArrayList;
-use LaravelJsonApi\Eloquent\Fields\Attribute;
 use LaravelJsonApi\Eloquent\Fields\Boolean;
 use LaravelJsonApi\Eloquent\Fields\ID;
 use LaravelJsonApi\Eloquent\Fields\Map;
 use LaravelJsonApi\Eloquent\Fields\Number;
-use LaravelJsonApi\Eloquent\Fields\Relations\Relation;
 use LaravelJsonApi\Eloquent\Pagination\CursorPagination;
 use LaravelJsonApi\Eloquent\Pagination\PagePagination;
 use LaravelJsonApi\OpenApiSpec\Builders\Paths\Operation\SchemaBuilder;
@@ -347,10 +347,10 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
         return collect($fields)
           ->mapToGroups(function (Field $field) {
               switch (true) {
-                  case $field instanceof Attribute:
+                  case $field instanceof AttributeContract:
                       $key = 'attributes';
                       break;
-                  case $field instanceof Relation:
+                  case $field instanceof RelationContract:
                       $key = 'relationships';
                       break;
                   default:
@@ -402,11 +402,11 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
 
               $schema = $fieldDataType->title($field->name());
 
-              $column = $field instanceof Attribute ? $field->column() : $field->name();
+              $column = $field instanceof AttributeContract ? $field->column() : $field->name();
               if (isset($example[$column])) {
                   $schema = $schema->example($example[$column]);
               }
-              if ($field->isReadOnly(null)) {
+              if (method_exists($field, 'isReadOnly') && $field->isReadOnly(null)) {
                   $schema = $schema->readOnly(true);
               }
 
@@ -427,22 +427,22 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
       JsonApiResource $example
     ): array {
         return $relationships
-          ->map(function (Relation $relation) use ($example) {
+          ->map(function (RelationContract $relation) use ($example) {
               return $this->relationship($relation, $example);
           })->toArray();
     }
 
     /**
-     * @param \LaravelJsonApi\Eloquent\Fields\Relations\Relation $relation
-     * @param \LaravelJsonApi\Core\Resources\JsonApiResource     $example
-     * @param bool                                               $includeData
+     * @param \LaravelJsonApi\Contracts\Schema\Relation      $relation
+     * @param \LaravelJsonApi\Core\Resources\JsonApiResource $example
+     * @param bool                                           $includeData
      *
      * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
      *
      * @return \GoldSpecDigital\ObjectOrientedOAS\Objects\Schema
      */
     protected function relationship(
-      Relation $relation,
+      RelationContract $relation,
       JsonApiResource $example,
       bool $includeData = false
     ): OASchema {
@@ -469,16 +469,16 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
     }
 
     /**
-     * @param \LaravelJsonApi\Eloquent\Fields\Relations\Relation $relation
-     * @param \LaravelJsonApi\Core\Resources\JsonApiResource     $example
-     * @param string                                             $type
+     * @param \LaravelJsonApi\Contracts\Schema\Relation      $relation
+     * @param \LaravelJsonApi\Core\Resources\JsonApiResource $example
+     * @param string                                         $type
      *
      * @throws \GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException
      *
      * @return \GoldSpecDigital\ObjectOrientedOAS\Objects\Schema
      */
     protected function relationshipData(
-      Relation $relation,
+      RelationContract $relation,
       JsonApiResource $example,
       string $type
     ): OASchema {
@@ -524,7 +524,9 @@ class Schema extends Descriptor implements SchemaDescriptor, SortablesDescriptor
       string $type
     ): OASchema {
         $name = Str::dasherize(
-            Str::plural($relation->relationName())
+            Str::plural(method_exists($relation, 'relationName')
+                ? $relation->relationName()
+                : Str::camel($relation->name()))
         );
 
         /*


### PR DESCRIPTION
## Description

Add initial support for non-Eloquent resources

## Motivation and context

Laravel JSON:API offers support for non-Eloquent resources.
This PR add initial support for non-Eloquent resources.

It isn't flawless because, the entity under the hood needs to implement `ArrayAccess` and have static `all` method (which is needed to generate examples). But it's a good start.

## How has this been tested?

Tests are green and the JSON file is generating.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](https://github.com/swisnl/openapi-spec-generator/blob/master/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
