### PR TITLE
Allow the use of non eloquent resources without extra configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '8.0', '8.1' ]
+        php: [ '8.0', '8.1' ]
         stability: [ prefer-lowest, prefer-stable ]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "ext-json": "*",
         "friendsofphp/php-cs-fixer": "^3.14",
         "laravel-json-api/laravel": "^2.0|^3.0",
+        "laravel-json-api/non-eloquent": "^3.0",
         "orchestra/testbench": "^6.25|^7.21|^8.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4|^8.0",
+        "php": "^8.0",
         "goldspecdigital/oooas": "^2.8",
         "justinrainbow/json-schema": "^5.2",
         "laravel-json-api/hashids": "^1.1|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ext-json": "*",
         "friendsofphp/php-cs-fixer": "^3.14",
         "laravel-json-api/laravel": "^2.0|^3.0",
-        "laravel-json-api/non-eloquent": "^3.0",
+        "laravel-json-api/non-eloquent": "^2.0|^3.0",
         "orchestra/testbench": "^6.25|^7.21|^8.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/sites.json
+++ b/sites.json
@@ -1,0 +1,10 @@
+{
+    "example": {
+        "domain": "johnsmith.com",
+        "name": "Johns site"
+    },
+    "foo": {
+        "domain": "foo.bar",
+        "name": "Foo Bar"
+    }
+}

--- a/src/Builders/Paths/Operation/RequestBodyBuilder.php
+++ b/src/Builders/Paths/Operation/RequestBodyBuilder.php
@@ -26,8 +26,8 @@ class RequestBodyBuilder extends Builder
     ];
 
     public function __construct(
-      Generator $generator,
-      SchemaBuilder $schemaBuilder
+        Generator $generator,
+        SchemaBuilder $schemaBuilder
     ) {
         parent::__construct($generator);
         $this->schemaBuilder = $schemaBuilder;

--- a/src/Builders/Paths/Operation/ResponseBuilder.php
+++ b/src/Builders/Paths/Operation/ResponseBuilder.php
@@ -43,9 +43,9 @@ class ResponseBuilder extends Builder
     ];
 
     public function __construct(
-      Generator $generator,
-      ComponentsContainer $components,
-      SchemaBuilder $schemaBuilder
+        Generator $generator,
+        ComponentsContainer $components,
+        SchemaBuilder $schemaBuilder
     ) {
         parent::__construct($generator);
         $this->components = $components;
@@ -72,9 +72,9 @@ class ResponseBuilder extends Builder
      * @return \GoldSpecDigital\ObjectOrientedOAS\Objects\Schema
      */
     public static function buildResponse(
-      SchemaContract $data,
-      Schema $meta = null,
-      Schema $links = null
+        SchemaContract $data,
+        Schema $meta = null,
+        Schema $links = null
     ): Schema {
         $jsonapi = Schema::object('jsonapi')
           ->properties(Schema::string('version')

--- a/src/Builders/Paths/Operation/SchemaBuilder.php
+++ b/src/Builders/Paths/Operation/SchemaBuilder.php
@@ -22,8 +22,8 @@ class SchemaBuilder extends Builder
      * @param \LaravelJsonApi\OpenApiSpec\ComponentsContainer $components
      */
     public function __construct(
-      Generator $generator,
-      ComponentsContainer $components
+        Generator $generator,
+        ComponentsContainer $components
     ) {
         parent::__construct($generator);
         $this->components = $components;
@@ -69,9 +69,9 @@ class SchemaBuilder extends Builder
      * @return \GoldSpecDigital\ObjectOrientedOAS\Contracts\SchemaContract
      */
     protected function buildResponseSchema(
-      Route $route,
-      SchemaDescriptorContract $descriptor,
-      string $objectId
+        Route $route,
+        SchemaDescriptorContract $descriptor,
+        string $objectId
     ): SchemaContract {
         $method = $route->action();
 
@@ -142,9 +142,9 @@ class SchemaBuilder extends Builder
      * @return \GoldSpecDigital\ObjectOrientedOAS\Contracts\SchemaContract
      */
     protected function buildRequestSchema(
-      Route $route,
-      SchemaDescriptorContract $descriptor,
-      string $objectId
+        Route $route,
+        SchemaDescriptorContract $descriptor,
+        string $objectId
     ): SchemaContract {
         $method = $route->action();
         if ($route->isRelation()) {
@@ -184,8 +184,8 @@ class SchemaBuilder extends Builder
      * @return string
      */
     public static function objectId(
-      Route $route,
-      bool $isRequest = false
+        Route $route,
+        bool $isRequest = false
     ): string {
         if ($isRequest) {
             $method = $route->action();

--- a/src/Builders/Paths/OperationBuilder.php
+++ b/src/Builders/Paths/OperationBuilder.php
@@ -44,8 +44,8 @@ class OperationBuilder extends Builder
     ];
 
     public function __construct(
-      Generator $generator,
-      ComponentsContainer $components
+        Generator $generator,
+        ComponentsContainer $components
     ) {
         parent::__construct($generator);
         $this->components = $components;

--- a/src/Builders/PathsBuilder.php
+++ b/src/Builders/PathsBuilder.php
@@ -18,8 +18,8 @@ class PathsBuilder extends Builder
     protected OperationBuilder $operation;
 
     public function __construct(
-      Generator $generator,
-      ComponentsContainer $components
+        Generator $generator,
+        ComponentsContainer $components
     ) {
         parent::__construct($generator);
         $this->components = $components;

--- a/src/Descriptors/Actions/ActionDescriptor.php
+++ b/src/Descriptors/Actions/ActionDescriptor.php
@@ -28,11 +28,11 @@ abstract class ActionDescriptor implements ActionDescriptorContract
     protected Route $route;
 
     public function __construct(
-      ParameterBuilder $parameterBuilder,
-      RequestBodyBuilder $requestBodyBuilder,
-      ResponseBuilder $responseBuilder,
-      Generator $generator,
-      Route $route
+        ParameterBuilder $parameterBuilder,
+        RequestBodyBuilder $requestBodyBuilder,
+        ResponseBuilder $responseBuilder,
+        Generator $generator,
+        Route $route
     ) {
         $this->parameterBuilder = $parameterBuilder;
         $this->requestBodyBuilder = $requestBodyBuilder;

--- a/src/Descriptors/Requests/RequestDescriptor.php
+++ b/src/Descriptors/Requests/RequestDescriptor.php
@@ -26,9 +26,9 @@ abstract class RequestDescriptor extends Descriptor implements RequestDescriptor
     protected SchemaBuilder $schemaBuilder;
 
     public function __construct(
-      Generator $generator,
-      Route $route,
-      SchemaBuilder $schemaBuilder
+        Generator $generator,
+        Route $route,
+        SchemaBuilder $schemaBuilder
     ) {
         parent::__construct($generator);
         $this->route = $route;

--- a/src/Descriptors/Responses/ResponseDescriptor.php
+++ b/src/Descriptors/Responses/ResponseDescriptor.php
@@ -31,10 +31,10 @@ abstract class ResponseDescriptor extends Descriptor implements ResponseDescript
     protected bool $validates = false;
 
     public function __construct(
-      Generator $generator,
-      Route $route,
-      SchemaBuilder $schemaBuilder,
-      Collection $defaults
+        Generator $generator,
+        Route $route,
+        SchemaBuilder $schemaBuilder,
+        Collection $defaults
     ) {
         parent::__construct($generator);
         $this->route = $route;

--- a/src/ResourceContainer.php
+++ b/src/ResourceContainer.php
@@ -26,7 +26,7 @@ class ResourceContainer
     public function resource($model): JsonApiResource
     {
         $fqn = $this->getFQN($model);
-        if (!isset($this->resource[$fqn])) {
+        if (!isset($this->resources[$fqn])) {
             $this->loadResources($fqn);
         }
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -279,8 +279,8 @@ class Route
     }
 
     public static function belongsTo(
-      IlluminateRoute $route,
-      Server $server
+        IlluminateRoute $route,
+        Server $server
     ): bool {
         return Str::contains(
             $route->getName(),
@@ -288,19 +288,19 @@ class Route
         );
     }
 
-  protected function setUriForRoute(): void
-  {
-      $domain = URL::to('/');
-      $serverBasePath = str_replace(
-          $domain,
-          '',
-          $this->server->url(),
-      );
+    protected function setUriForRoute(): void
+    {
+        $domain = URL::to('/');
+        $serverBasePath = str_replace(
+            $domain,
+            '',
+            $this->server->url(),
+        );
 
-      $this->uri = str_replace(
-          $serverBasePath,
-          '',
-          '/'.$this->route->uri(),
-      );
-  }
+        $this->uri = str_replace(
+            $serverBasePath,
+            '',
+            '/'.$this->route->uri(),
+        );
+    }
 }

--- a/tests/Feature/OpenApiSchemaTest.php
+++ b/tests/Feature/OpenApiSchemaTest.php
@@ -41,4 +41,10 @@ class OpenApiSchemaTest extends TestCase
     {
         $this->assertEquals('', $this->spec['paths']['/videos']['get']['description']);
     }
+
+    public function testItDescribesNonEloquentResources(): void
+    {
+        $this->assertEquals('Get all sites', $this->spec['paths']['/sites']['get']['summary']);
+        $this->assertEquals('object', $this->spec['components']['schemas']['resources.sites.resource.fetch']['type']);
+    }
 }

--- a/tests/Support/Controllers/Api/V1/SiteController.php
+++ b/tests/Support/Controllers/Api/V1/SiteController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Support\Controllers\Api\V1;
+
+use LaravelJsonApi\Laravel\Http\Controllers\Actions;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Controllers\Controller;
+
+class SiteController extends Controller
+{
+    use Actions\FetchMany;
+    use Actions\FetchOne;
+    use Actions\Store;
+}

--- a/tests/Support/Database/Migrations/2020_06_13_143800_create_post_and_video_tables.php
+++ b/tests/Support/Database/Migrations/2020_06_13_143800_create_post_and_video_tables.php
@@ -167,6 +167,6 @@ class CreatePostAndVideoTables extends Migration
         Schema::dropIfExists('tags');
         Schema::dropIfExists('comments');
         Schema::dropIfExists('videos');
-//        Schema::dropIfExists('posts');
+        //        Schema::dropIfExists('posts');
     }
 }

--- a/tests/Support/Entities/Site.php
+++ b/tests/Support/Entities/Site.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaravelJsonApi\OpenApiSpec\Tests\Support\Entities;
 
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Collection;
 
 class Site implements Arrayable
 {
@@ -49,16 +48,6 @@ class Site implements Arrayable
     public function getName(): ?string
     {
         return $this->name;
-    }
-
-    public static function all(): Collection
-    {
-        return collect([
-            self::fromArray('example', [
-                'domain' => 'example.com',
-                'name' => 'Johns Site',
-            ]),
-        ]);
     }
 
     public function setName(?string $name): Site

--- a/tests/Support/Entities/Site.php
+++ b/tests/Support/Entities/Site.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Support\Entities;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+
+class Site implements Arrayable
+{
+    private string $slug;
+
+    private ?string $domain;
+
+    private ?string $name;
+
+    public static function fromArray(string $slug, array $values): self
+    {
+        $site = new self($slug);
+        $site->setDomain($values['domain'] ?? null);
+        $site->setName($values['name'] ?? null);
+
+        return $site;
+    }
+
+    public function __construct(string $slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getDomain(): ?string
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(?string $domain): Site
+    {
+        $this->domain = $domain;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public static function all(): Collection
+    {
+        return collect([
+            self::fromArray('example', [
+                'domain' => 'example.com',
+                'name' => 'Johns Site',
+            ]),
+        ]);
+    }
+
+    public function setName(?string $name): Site
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            $this->getDomain(),
+            $this->getName(),
+        ];
+    }
+}

--- a/tests/Support/Entities/SiteStorage.php
+++ b/tests/Support/Entities/SiteStorage.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Support\Entities;
+
+use Illuminate\Filesystem\Filesystem;
+
+class SiteStorage
+{
+    protected Filesystem $files;
+
+    /**
+     * @var array<int, array<string, mixed>
+     */
+    protected array $sites;
+
+    public function __construct(Filesystem $files)
+    {
+        $this->files = $files;
+        $this->sites = json_decode($files->get('sites.json'), true);
+    }
+
+    public function find(string $slug): ?Site
+    {
+        if (!isset($this->sites[$slug])) {
+            return null;
+        }
+
+        return Site::fromArray($slug, $this->sites[$slug]);
+    }
+
+    public function cursor(): \Generator
+    {
+        foreach ($this->sites as $slug => $values) {
+            yield $slug => Site::fromArray($slug, $values);
+        }
+    }
+
+    public function all(): array
+    {
+        return iterator_to_array($this->cursor());
+    }
+
+    public function store(Site $site): void
+    {
+        $this->sites[$site->getSlug()] = $site->toArray();
+
+        $this->write();
+    }
+
+    public function remove(Site $site): void
+    {
+        unset($this->sites[$site->getSlug()]);
+
+        $this->write();
+    }
+
+    public function write(): void
+    {
+        $this->files->put('sites.json', json_encode($this->sites));
+    }
+}

--- a/tests/Support/JsonApi/V1/Server.php
+++ b/tests/Support/JsonApi/V1/Server.php
@@ -69,6 +69,7 @@ class Server extends BaseServer
             Tags\TagSchema::class,
             Users\UserSchema::class,
             Videos\VideoSchema::class,
+            Sites\SiteSchema::class,
         ];
     }
 

--- a/tests/Support/JsonApi/V1/Sites/Capabilities/CrudSite.php
+++ b/tests/Support/JsonApi/V1/Sites/Capabilities/CrudSite.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Support\JsonApi\V1\Sites\Capabilities;
+
+use Illuminate\Support\Str;
+use LaravelJsonApi\NonEloquent\Capabilities\CrudResource;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Entities\Site;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Entities\SiteStorage;
+
+class CrudSite extends CrudResource
+{
+    protected SiteStorage $sites;
+
+    public function __construct(SiteStorage $sites)
+    {
+        parent::__construct();
+
+        $this->sites = $sites;
+    }
+
+    public function create(array $validatedData): Site
+    {
+        $site = new Site($validatedData['slug']);
+        $site->setDomain($validatedData['domain'] ?? null);
+        $site->setName($validatedData['name'] ?? null);
+
+        $this->sites->store($site);
+
+        return $site;
+    }
+
+    public function read(Site $site): ?Site
+    {
+        $filters = $this->queryParameters->filter();
+
+        if ($filters && $name = $filters->value('name')) {
+            return Str::contains($site->getName(), $name) ? $site : null;
+        }
+
+        return $site;
+    }
+
+    public function update(Site $site, array $validatedData): Site
+    {
+        if (array_key_exists('domain', $validatedData)) {
+            $site->setDomain($validatedData['domain']);
+        }
+
+        if (array_key_exists('name', $validatedData)) {
+            $site->setName($validatedData['name']);
+        }
+
+        $this->sites->store($site);
+
+        return $site;
+    }
+
+    public function delete(Site $site): void
+    {
+        $this->sites->remove($site);
+    }
+}

--- a/tests/Support/JsonApi/V1/Sites/Capabilities/QuerySites.php
+++ b/tests/Support/JsonApi/V1/Sites/Capabilities/QuerySites.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Support\JsonApi\V1\Sites\Capabilities;
+
+use LaravelJsonApi\NonEloquent\Capabilities\QueryAll;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Entities\Site;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Entities\SiteStorage;
+
+class QuerySites extends QueryAll
+{
+    protected SiteStorage $sites;
+
+    public function __construct(SiteStorage $sites)
+    {
+        parent::__construct();
+
+        $this->sites = $sites;
+    }
+
+    public function get(): iterable
+    {
+        $sites = collect($this->sites->all());
+        $filters = $this->queryParameters->filter();
+
+        if ($filters && is_array($slugs = $filters->value('slugs'))) {
+            $sites = $sites->filter(
+                fn (Site $site) => in_array($site->getSlug(), $slugs)
+            );
+        }
+
+        return $sites;
+    }
+}

--- a/tests/Support/JsonApi/V1/Sites/SiteRepository.php
+++ b/tests/Support/JsonApi/V1/Sites/SiteRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Support\JsonApi\V1\Sites;
+
+use LaravelJsonApi\Contracts\Store\CreatesResources;
+use LaravelJsonApi\Contracts\Store\DeletesResources;
+use LaravelJsonApi\Contracts\Store\QueriesAll;
+use LaravelJsonApi\Contracts\Store\QueryManyBuilder;
+use LaravelJsonApi\Contracts\Store\UpdatesResources;
+use LaravelJsonApi\NonEloquent\AbstractRepository;
+use LaravelJsonApi\NonEloquent\Concerns\HasCrudCapability;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Entities\SiteStorage;
+
+class SiteRepository extends AbstractRepository implements QueriesAll, CreatesResources, UpdatesResources, DeletesResources
+{
+    use HasCrudCapability;
+
+    protected SiteStorage $siteStorage;
+
+    public function __construct(SiteStorage $siteStorage)
+    {
+        $this->siteStorage = $siteStorage;
+    }
+
+    public function find(string $resourceId): ?object
+    {
+        return $this->siteStorage->find($resourceId);
+    }
+
+    public function queryAll(): QueryManyBuilder
+    {
+        return Capabilities\QuerySites::make()
+            ->withServer($this->server())
+            ->withSchema($this->schema());
+    }
+
+    protected function crud(): Capabilities\CrudSite
+    {
+        return Capabilities\CrudSite::make();
+    }
+}

--- a/tests/Support/JsonApi/V1/Sites/SiteResource.php
+++ b/tests/Support/JsonApi/V1/Sites/SiteResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Support\JsonApi\V1\Sites;
+
+use LaravelJsonApi\Core\Resources\JsonApiResource;
+
+class SiteResource extends JsonApiResource
+{
+    public function id(): string
+    {
+        return $this->resource->getSlug();
+    }
+
+    public function attributes($request): iterable
+    {
+        return [
+            'domain' => $this->resource->getDomain(),
+            'name' => $this->resource->getName(),
+        ];
+    }
+}

--- a/tests/Support/JsonApi/V1/Sites/SiteSchema.php
+++ b/tests/Support/JsonApi/V1/Sites/SiteSchema.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Support\JsonApi\V1\Sites;
+
+use LaravelJsonApi\Core\Schema\Schema;
+use LaravelJsonApi\NonEloquent\Fields\Attribute;
+use LaravelJsonApi\NonEloquent\Fields\ID;
+use LaravelJsonApi\NonEloquent\Filters\Filter;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Entities\Site;
+
+class SiteSchema extends Schema
+{
+    public static string $model = Site::class;
+
+    public function fields(): iterable
+    {
+        return [
+            ID::make(),
+            Attribute::make('domain'),
+            Attribute::make('name'),
+        ];
+    }
+
+    public function filters(): iterable
+    {
+        return [
+            Filter::make('slugs'),
+        ];
+    }
+
+    public function repository(): SiteRepository
+    {
+        return SiteRepository::make()
+            ->withServer($this->server)
+            ->withSchema($this);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace LaravelJsonApi\OpenApiSpec\Tests;
 
 use Illuminate\Support\Facades\App;
+use LaravelJsonApi\Laravel\Routing\Registrar;
+use LaravelJsonApi\Laravel\Routing\ResourceRegistrar;
 use LaravelJsonApi\OpenApiSpec\OpenApiServiceProvider;
 use LaravelJsonApi\OpenApiSpec\Tests\Support\JsonApi\V1\Server;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -30,12 +32,13 @@ abstract class TestCase extends BaseTestCase
     protected function defineRoutes($router)
     {
         $router->group(['prefix' => 'api', 'middleware' => 'api', 'namespace' => 'LaravelJsonApi\OpenApiSpec\Tests\Support\Controllers'], function () {
+            /** @var Registrar $jsonApiRoute */
             $jsonApiRoute = App::make(\LaravelJsonApi\Laravel\Routing\Registrar::class);
 
             $jsonApiRoute->server('v1')
               ->prefix('v1')
               ->namespace('Api\V1')
-              ->resources(function ($server) {
+              ->resources(function (ResourceRegistrar $server) {
                   /* Posts */
                   $server->resource('posts')->relationships(function ($relationships) {
                       $relationships->hasOne('author')->readOnly();
@@ -51,6 +54,8 @@ abstract class TestCase extends BaseTestCase
                   $server->resource('videos')->relationships(function ($relationships) {
                       $relationships->hasMany('tags');
                   });
+
+                  $server->resource('sites');
               });
         });
     }


### PR DESCRIPTION

## Description

This PR will allow developers to generate documentation for their non-eloquent resources. This is built upon the code of PR #17 and now it no longer requires the ArrayAccess interface and the all method on the resource.

## Motivation and context

This allows developers to generate the missing documentation for their non eloquent resources!

## How has this been tested?

Test data has been added to the package which is used to validate the functionality in the tests

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](https://github.com/swisnl/openapi-spec-generator/blob/master/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
