### PR TITLE
fix: use configured column name instead of key to retrieve example data

### DIFF
--- a/src/Descriptors/Schema/Filters/Where.php
+++ b/src/Descriptors/Schema/Filters/Where.php
@@ -5,18 +5,23 @@ namespace LaravelJsonApi\OpenApiSpec\Descriptors\Schema\Filters;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Example;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Parameter;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema as OASchema;
+use LaravelJsonApi\Contracts\Schema\Filter;
 
 class Where extends FilterDescriptor
 {
+    /**
+     * @var \LaravelJsonApi\Eloquent\Filters\Where
+     */
+    protected Filter $filter;
+
     /**
      * @todo Pay attention to isSingular
      */
     public function filter(): array
     {
-        $key = $this->filter->key();
         $examples = collect($this->generator->resources()
           ->resources($this->route->schema()::model()))
-          ->pluck($key)
+          ->pluck($this->filter->column())
           ->filter()
           ->map(function ($f) {
               if (function_exists('enum_exists') && $f instanceof \UnitEnum) {

--- a/src/Descriptors/Schema/Filters/WhereIn.php
+++ b/src/Descriptors/Schema/Filters/WhereIn.php
@@ -5,20 +5,25 @@ namespace LaravelJsonApi\OpenApiSpec\Descriptors\Schema\Filters;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Example;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Parameter;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+use LaravelJsonApi\Contracts\Schema\Filter;
 use LaravelJsonApi\Eloquent\Filters\WhereNotIn;
 use LaravelJsonApi\Eloquent\Filters\WherePivotNotIn;
 
 class WhereIn extends FilterDescriptor
 {
     /**
+     * @var \LaravelJsonApi\Eloquent\Filters\WhereIn
+     */
+    protected Filter $filter;
+
+    /**
      * @todo Pay attention to delimiter
      */
     public function filter(): array
     {
-        $key = $this->filter->key();
         $examples = collect($this->generator->resources()
           ->resources($this->route->schema()::model()))
-          ->pluck($key)
+          ->pluck($this->filter->column())
           ->filter()
           ->map(function ($f) {
               if (function_exists('enum_exists') && $f instanceof \UnitEnum) {


### PR DESCRIPTION
## Description

Given the following configured schema filters, this spec generator package tries to retrieve example data from the model using the `event` key name which is incorrect because a column name is provided.

```php
public function filters(): array
{
    return [Where::make(name: 'event', column: 'event_class')];
}
```

## Motivation and context

Without this fix, it's impossible to generate specs when using `column` configuration.

## How has this been tested?

Tested by running generate command.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](https://github.com/swisnl/openapi-spec-generator/blob/master/CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
