### PR TITLE
Upgrade laravel json api v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ vendor
 .php-cs-fixer.php
 .php-cs-fixer.cache
 phpunit.xml
-.phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -40,16 +40,16 @@
         "php": "^8.0",
         "goldspecdigital/oooas": "^2.8",
         "justinrainbow/json-schema": "^5.2",
-        "laravel-json-api/hashids": "^1.1|^2.0",
-        "symfony/yaml": "^5.3|^6.0"
+        "laravel-json-api/hashids": "^3.0",
+        "symfony/yaml": "^7.0"
     },
     "require-dev": {
         "ext-json": "*",
         "friendsofphp/php-cs-fixer": "^3.14",
-        "laravel-json-api/laravel": "^2.0|^3.0",
-        "laravel-json-api/non-eloquent": "^2.0|^3.0",
-        "orchestra/testbench": "^6.25|^7.21|^8.0",
-        "phpunit/phpunit": "^9.5"
+        "laravel-json-api/laravel": "^4.0",
+        "laravel-json-api/non-eloquent": "^4.0",
+        "orchestra/testbench": "^9.0",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -40,16 +40,16 @@
         "php": "^8.0",
         "goldspecdigital/oooas": "^2.8",
         "justinrainbow/json-schema": "^5.2",
-        "laravel-json-api/hashids": "^3.0",
-        "symfony/yaml": "^7.0"
+        "laravel-json-api/hashids": "^1.1|^2.0|^3.0",
+        "symfony/yaml": "^5.3|^6.0|^7.0"
     },
     "require-dev": {
         "ext-json": "*",
         "friendsofphp/php-cs-fixer": "^3.14",
-        "laravel-json-api/laravel": "^4.0",
-        "laravel-json-api/non-eloquent": "^4.0",
-        "orchestra/testbench": "^9.0",
-        "phpunit/phpunit": "^10.5"
+        "laravel-json-api/laravel": "^2.0|^3.0|^4.0",
+        "laravel-json-api/non-eloquent": "^2.0|^3.0|^4.0",
+        "orchestra/testbench": "^6.25|^7.21|^8.0|^9.0",
+        "phpunit/phpunit": "^9.5|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <testsuites>
-    <testsuite name="Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <php>
-    <server name="APP_ENV" value="testing"/>
-    <server name="BCRYPT_ROUNDS" value="4"/>
-    <server name="CACHE_DRIVER" value="array"/>
-    <server name="DB_CONNECTION" value="sqlite"/>
-    <server name="DB_DATABASE" value=":memory:"/>
-    <server name="MAIL_MAILER" value="array"/>
-    <server name="QUEUE_CONNECTION" value="sync"/>
-    <server name="SESSION_DRIVER" value="array"/>
-    <server name="TELESCOPE_ENABLED" value="false"/>
-  </php>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <server name="APP_ENV" value="testing"/>
+        <server name="BCRYPT_ROUNDS" value="4"/>
+        <server name="CACHE_DRIVER" value="array"/>
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
+        <server name="MAIL_MAILER" value="array"/>
+        <server name="QUEUE_CONNECTION" value="sync"/>
+        <server name="SESSION_DRIVER" value="array"/>
+        <server name="TELESCOPE_ENABLED" value="false"/>
+    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <server name="APP_ENV" value="testing"/>
-        <server name="BCRYPT_ROUNDS" value="4"/>
-        <server name="CACHE_DRIVER" value="array"/>
-        <server name="DB_CONNECTION" value="sqlite"/>
-        <server name="DB_DATABASE" value=":memory:"/>
-        <server name="MAIL_MAILER" value="array"/>
-        <server name="QUEUE_CONNECTION" value="sync"/>
-        <server name="SESSION_DRIVER" value="array"/>
-        <server name="TELESCOPE_ENABLED" value="false"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_ENV" value="testing"/>
+    <server name="BCRYPT_ROUNDS" value="4"/>
+    <server name="CACHE_DRIVER" value="array"/>
+    <server name="DB_CONNECTION" value="sqlite"/>
+    <server name="DB_DATABASE" value=":memory:"/>
+    <server name="MAIL_MAILER" value="array"/>
+    <server name="QUEUE_CONNECTION" value="sync"/>
+    <server name="SESSION_DRIVER" value="array"/>
+    <server name="TELESCOPE_ENABLED" value="false"/>
+  </php>
 </phpunit>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Upgrade Openapi Spec Generator to support Laravel Json Api v4

Add support to openapi-spec-generator for laravel-json-api/laravel v4 upgrade.

## Upgraded packages:

"laravel-json-api/hashids": "^1.1|^2.0|^3.0",
"symfony/yaml": "^5.3|^6.0|^7.0"
"laravel-json-api/laravel": "^2.0|^3.0|^4.0",
"laravel-json-api/non-eloquent": "^2.0|^3.0|^4.0",
"orchestra/testbench": "^6.25|^7.21|^8.0|^9.0",
"phpunit/phpunit": "^9.5|^10.5"

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
