### PR TITLE
Update to allow for Laravel 11 and Laravel JSON:API v5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 vendor
 phpunit.xml
 .phpunit.result.cache
+.phpunit.cache/test-results

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "laravel/pint": "^1.20",
         "nesbot/carbon": "^2.63|^3.0",
         "orchestra/testbench": "^6.25|^7.21|^8.0|^9.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "laravel-json-api/laravel": "^2.0|^3.0|^4.0",
+        "laravel-json-api/laravel": "^2.0|^3.0|^4.0|^5.0",
         "laravel-json-api/non-eloquent": "^2.0|^3.0|^v4.0",
         "laravel/pint": "^1.20",
         "nesbot/carbon": "^2.63|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "laravel/pint": "^1.20",
         "nesbot/carbon": "^2.63|^3.0",
         "orchestra/testbench": "^6.25|^7.21|^8.0|^9.0",
-        "phpunit/phpunit": "^9.5|^10.0|^11.0"
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+<phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
+         backupStaticProperties="false"
          colors="true"
          processIsolation="false"
-         stopOnFailure="false"
          cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
     <php>
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates `composer.json` to allow for Laravel 11 and JSON:API v5.x support. Also includes bump to support PHPUnit 10 and/or PHPUnit 11 as required.

## Motivation and context

Needed for Laravel 11 support.

## How has this been tested?

```
PHPUnit 11.5.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.9
Configuration: /Users/david.weston/www-data/openapi-spec-generator/phpunit.xml.dist

........                                                            8 / 8 (100%)

Time: 00:01.263, Memory: 46.50 MB

OK (8 tests, 15 assertions)
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](https://github.com/swisnl/openapi-spec-generator/blob/master/CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
